### PR TITLE
limit auth changes

### DIFF
--- a/contracts/eosio.system/CMakeLists.txt
+++ b/contracts/eosio.system/CMakeLists.txt
@@ -8,6 +8,7 @@ add_contract(eosio.system eosio.system
    ${CMAKE_CURRENT_SOURCE_DIR}/src/powerup.cpp
    ${CMAKE_CURRENT_SOURCE_DIR}/src/rex.cpp
    ${CMAKE_CURRENT_SOURCE_DIR}/src/voting.cpp
+   ${CMAKE_CURRENT_SOURCE_DIR}/src/limit_auth_changes.cpp
 )
 
 target_include_directories(eosio.system

--- a/contracts/eosio.system/include/eosio.system/eosio.system.hpp
+++ b/contracts/eosio.system/include/eosio.system/eosio.system.hpp
@@ -1328,6 +1328,24 @@ namespace eosiosystem {
          [[eosio::action]]
          void powerup( const name& payer, const name& receiver, uint32_t days, int64_t net_frac, int64_t cpu_frac, const asset& max_payment );
 
+         /**
+          * limitauthchg opts into or out of restrictions on updateauth, deleteauth, linkauth, and unlinkauth.
+          *
+          * If either allow_perms or disallow_perms is non-empty, then opts into restrictions. If
+          * allow_perms is non-empty, then the authorized_by argument of the restricted actions must be in
+          * the vector, or the actions will abort. If disallow_perms is non-empty, then the authorized_by
+          * argument of the restricted actions must not be in the vector, or the actions will abort.
+          *
+          * If both allow_perms and disallow_perms are empty, then opts out of the restrictions. limitauthchg
+          * aborts if both allow_perms and disallow_perms are non-empty.
+          *
+          * @param account - account to change
+          * @param allow_perms - permissions which may use the restricted actions
+          * @param disallow_perms - permissions which may not use the restricted actions
+          */
+         [[eosio::action]]
+         void limitauthchg( const name& account, const std::vector<name>& allow_perms, const std::vector<name>& disallow_perms );
+
          using init_action = eosio::action_wrapper<"init"_n, &system_contract::init>;
          using setacctram_action = eosio::action_wrapper<"setacctram"_n, &system_contract::setacctram>;
          using setacctnet_action = eosio::action_wrapper<"setacctnet"_n, &system_contract::setacctnet>;

--- a/contracts/eosio.system/include/eosio.system/limit_auth_changes.hpp
+++ b/contracts/eosio.system/include/eosio.system/limit_auth_changes.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <eosio/multi_index.hpp>
+
+namespace eosiosystem {
+   using eosio::name;
+
+   struct [[eosio::table("limitauthchg"),eosio::contract("eosio.system")]] limit_auth_change {
+      uint8_t              version = 0;
+      name                 account;
+      std::vector<name>    allow_perms;
+      std::vector<name>    disallow_perms;
+
+      uint64_t primary_key() const { return account.value; }
+
+      EOSLIB_SERIALIZE(limit_auth_change, (version)(account)(allow_perms)(disallow_perms))
+   };
+
+   typedef eosio::multi_index<"limitauthchg"_n, limit_auth_change> limit_auth_change_table;
+} // namespace eosiosystem

--- a/contracts/eosio.system/src/limit_auth_changes.cpp
+++ b/contracts/eosio.system/src/limit_auth_changes.cpp
@@ -8,6 +8,12 @@ namespace eosiosystem {
       limit_auth_change_table table(get_self(), get_self().value);
       require_auth(account);
       eosio::check(allow_perms.empty() || disallow_perms.empty(), "either allow_perms or disallow_perms must be empty");
+      eosio::check(allow_perms.empty() ||
+                   std::find(allow_perms.begin(), allow_perms.end(), "owner"_n) != allow_perms.end(),
+                   "allow_perms does not contain owner");
+      eosio::check(disallow_perms.empty() ||
+                   std::find(disallow_perms.begin(), disallow_perms.end(), "owner"_n) == disallow_perms.end(),
+                   "disallow_perms contains owner");
       auto it = table.find(account.value);
       if(!allow_perms.empty() || !disallow_perms.empty()) {
          if(it == table.end()) {

--- a/contracts/eosio.system/src/limit_auth_changes.cpp
+++ b/contracts/eosio.system/src/limit_auth_changes.cpp
@@ -1,0 +1,50 @@
+#include <eosio.system/limit_auth_changes.hpp>
+#include <eosio.system/eosio.system.hpp>
+
+namespace eosiosystem {
+
+   void system_contract::limitauthchg(const name& account, const std::vector<name>& allow_perms,
+                                      const std::vector<name>& disallow_perms) {
+      limit_auth_change_table table(get_self(), get_self().value);
+      require_auth(account);
+      eosio::check(allow_perms.empty() || disallow_perms.empty(), "either allow_perms or disallow_perms must be empty");
+      auto it = table.find(account.value);
+      if(!allow_perms.empty() || !disallow_perms.empty()) {
+         if(it == table.end()) {
+            table.emplace(account, [&](auto& row){
+               row.account = account;
+               row.allow_perms = allow_perms;
+               row.disallow_perms = disallow_perms;
+            });
+         } else {
+            table.modify(it, account, [&](auto& row){
+               row.allow_perms = allow_perms;
+               row.disallow_perms = disallow_perms;
+            });
+         }
+      } else {
+         if(it != table.end())
+            table.erase(it);
+      }
+   }
+
+   void check_auth_change(name contract, name account, const binary_extension<name>& authorized_by) {
+      name by(authorized_by.has_value() ? authorized_by.value().value : 0);
+      if(by.value)
+         eosio::require_auth({account, by});
+      limit_auth_change_table table(contract, contract.value);
+      auto it = table.find(account.value);
+      if(it == table.end())
+         return;
+      eosio::check(by.value, "authorized_by is required for this account");
+      if(!it->allow_perms.empty())
+         eosio::check(
+            std::find(it->allow_perms.begin(), it->allow_perms.end(), by) != it->allow_perms.end(),
+            "authorized_by does not appear in allow_perms");
+      else
+         eosio::check(
+            std::find(it->disallow_perms.begin(), it->disallow_perms.end(), by) == it->disallow_perms.end(),
+            "authorized_by appears in disallow_perms");
+   }
+
+} // namespace eosiosystem

--- a/tests/eosio.limitauth_tests.cpp
+++ b/tests/eosio.limitauth_tests.cpp
@@ -1,0 +1,500 @@
+#include <Runtime/Runtime.h>
+#include <boost/test/unit_test.hpp>
+#include <cstdlib>
+#include <eosio/chain/contract_table_objects.hpp>
+#include <eosio/chain/exceptions.hpp>
+#include <eosio/chain/global_property_object.hpp>
+#include <eosio/chain/resource_limits.hpp>
+#include <eosio/chain/wast_to_wasm.hpp>
+#include <fc/log/logger.hpp>
+#include <iostream>
+#include <sstream>
+
+#include "eosio.system_tester.hpp"
+
+using namespace eosio_system;
+
+inline const auto owner = N(owner);
+inline const auto active = N(active);
+inline const auto admin = N(admin);
+inline const auto admin2 = N(admin2);
+inline const auto freebie = N(freebie);
+inline const auto freebie2 = N(freebie2);
+
+inline const auto alice = N(alice1111111);
+inline const auto bob = N(bob111111111);
+
+struct limitauth_tester: eosio_system_tester {
+   action_result push_action(name code, name action, permission_level auth, const variant_object& data) {
+      try {
+         TESTER::push_action(code, action, {auth}, data);
+         return "";
+      } catch (const fc::exception& ex) {
+         edump((ex.to_detail_string()));
+         return ex.top_message();
+      }
+   }
+
+   action_result limitauthchg(permission_level pl, const name& account, const std::vector<name>& allow_perms, const std::vector<name>& disallow_perms) {
+      return push_action(
+         config::system_account_name, N(limitauthchg), pl,
+         mvo()("account", account)("allow_perms", allow_perms)("disallow_perms", disallow_perms));
+   }
+
+   template<typename... Ts>
+   action_result push_action_raw(name code, name act, permission_level pl, const Ts&... data) {
+      try {
+         fc::datastream<size_t> sz;
+         (fc::raw::pack(sz, data), ...);
+         std::vector<char> vec(sz.tellp());
+         fc::datastream<char*> ds(vec.data(), size_t(vec.size()));
+         (fc::raw::pack(ds, data), ...);
+
+         signed_transaction trx;
+         trx.actions.push_back(action{{pl}, code, act, std::move(vec)});
+
+         set_transaction_headers(trx, DEFAULT_EXPIRATION_DELTA, 0);
+         trx.sign(get_private_key(pl.actor, pl.permission.to_string()), control->get_chain_id());
+         push_transaction(trx);
+         return "";
+      } catch (const fc::exception& ex) {
+         edump((ex.to_detail_string()));
+         return ex.top_message();
+      }
+   }
+
+   /////////////
+   // This set tests using the native abi (no authorized_by)
+
+   action_result updateauth(permission_level pl, name account, name permission, name parent, authority auth) {
+      return push_action_raw(
+         config::system_account_name, N(updateauth), pl, account, permission, parent, auth);
+   }
+
+   action_result deleteauth(permission_level pl, name account, name permission) {
+      return push_action_raw(
+         config::system_account_name, N(deleteauth), pl, account, permission);
+   }
+
+   action_result linkauth(permission_level pl, name account, name code, name type, name requirement) {
+      return push_action_raw(
+         config::system_account_name, N(linkauth), pl, account, code, type, requirement);
+   }
+
+   action_result unlinkauth(permission_level pl, name account, name code, name type) {
+      return push_action_raw(
+         config::system_account_name, N(unlinkauth), pl, account, code, type);
+   }
+
+   /////////////
+   // This set tests using the extended abi (includes authorized_by)
+
+   action_result updateauth(permission_level pl, name account, name permission, name parent, authority auth, name authorized_by) {
+      return push_action_raw(
+         config::system_account_name, N(updateauth), pl, account, permission, parent, auth, authorized_by);
+   }
+
+   action_result deleteauth(permission_level pl, name account, name permission, name authorized_by) {
+      return push_action_raw(
+         config::system_account_name, N(deleteauth), pl, account, permission, authorized_by);
+   }
+
+   action_result linkauth(permission_level pl, name account, name code, name type, name requirement, name authorized_by) {
+      return push_action_raw(
+         config::system_account_name, N(linkauth), pl, account, code, type, requirement, authorized_by);
+   }
+
+   action_result unlinkauth(permission_level pl, name account, name code, name type, name authorized_by) {
+      return push_action_raw(
+         config::system_account_name, N(unlinkauth), pl, account, code, type, authorized_by);
+   }
+}; // limitauth_tester
+
+BOOST_AUTO_TEST_SUITE(eosio_system_limitauth_tests)
+
+// alice hasn't opted in; she can still use the native abi (no authorized_by)
+BOOST_FIXTURE_TEST_CASE(native_tests, limitauth_tester) try {
+   BOOST_REQUIRE_EQUAL(
+      "",
+      updateauth({alice, active}, alice, freebie, active, get_public_key(alice, "freebie")));
+   BOOST_REQUIRE_EQUAL(
+      "",
+      linkauth({alice, active}, alice, N(eosio.null), N(noop), freebie));
+
+   // alice@freebie can create alice@freebie2
+   BOOST_REQUIRE_EQUAL(
+      "",
+      updateauth({alice, freebie}, alice, freebie2, freebie, get_public_key(alice, "freebie2")));
+
+   // alice@freebie can linkauth
+   BOOST_REQUIRE_EQUAL(
+      "",
+      linkauth({alice, freebie}, alice, N(eosio.null), N(noop), freebie2));
+
+   // alice@freebie can unlinkauth
+   BOOST_REQUIRE_EQUAL(
+      "",
+      unlinkauth({alice, freebie}, alice, N(eosio.null), N(noop)));
+
+   // alice@freebie can delete alice@freebie2
+   BOOST_REQUIRE_EQUAL(
+      "",
+      deleteauth({alice, freebie}, alice, freebie2));
+
+   // bob, who has the published freebie key, attacks
+   BOOST_REQUIRE_EQUAL(
+      "",
+      updateauth({alice, freebie}, alice, freebie, active, get_public_key(bob, "attack")));
+} // native_tests
+FC_LOG_AND_RETHROW()
+
+// alice hasn't opted in; she can use the extended abi, but set authorized_by to empty
+BOOST_FIXTURE_TEST_CASE(extended_empty_tests, limitauth_tester) try {
+   BOOST_REQUIRE_EQUAL(
+      "",
+      updateauth({alice, active}, alice, freebie, active, get_public_key(alice, "freebie"), N()));
+   BOOST_REQUIRE_EQUAL(
+      "",
+      linkauth({alice, active}, alice, N(eosio.null), N(noop), freebie, N()));
+
+   // alice@freebie can create alice@freebie2
+   BOOST_REQUIRE_EQUAL(
+      "",
+      updateauth({alice, freebie}, alice, freebie2, freebie, get_public_key(alice, "freebie2"), N()));
+
+   // alice@freebie can linkauth
+   BOOST_REQUIRE_EQUAL(
+      "",
+      linkauth({alice, freebie}, alice, N(eosio.null), N(noop), freebie2, N()));
+
+   // alice@freebie can unlinkauth
+   BOOST_REQUIRE_EQUAL(
+      "",
+      unlinkauth({alice, freebie}, alice, N(eosio.null), N(noop), N()));
+
+   // alice@freebie can delete alice@freebie2
+   BOOST_REQUIRE_EQUAL(
+      "",
+      deleteauth({alice, freebie}, alice, freebie2, N()));
+
+   // bob, who has the published freebie key, attacks
+   BOOST_REQUIRE_EQUAL(
+      "",
+      updateauth({alice, freebie}, alice, freebie, active, get_public_key(bob, "attack"), N()));
+} // extended_empty_tests
+FC_LOG_AND_RETHROW()
+
+// alice hasn't opted in; she can use the extended abi, but set authorized_by to matching values
+BOOST_FIXTURE_TEST_CASE(extended_matching_tests, limitauth_tester) try {
+   BOOST_REQUIRE_EQUAL(
+      "missing authority of alice1111111/owner",
+      updateauth({alice, active}, alice, freebie, active, get_public_key(alice, "freebie"), owner));
+   BOOST_REQUIRE_EQUAL(
+      "",
+      updateauth({alice, active}, alice, freebie, active, get_public_key(alice, "freebie"), active));
+
+   BOOST_REQUIRE_EQUAL(
+      "missing authority of alice1111111/owner",
+      linkauth({alice, active}, alice, N(eosio.null), N(noop), freebie, owner));
+   BOOST_REQUIRE_EQUAL(
+      "",
+      linkauth({alice, active}, alice, N(eosio.null), N(noop), freebie, active));
+
+   // alice@freebie can create alice@freebie2
+   BOOST_REQUIRE_EQUAL(
+      "",
+      updateauth({alice, freebie}, alice, freebie2, freebie, get_public_key(alice, "freebie2"), freebie));
+
+   // alice@freebie can linkauth
+   BOOST_REQUIRE_EQUAL(
+      "",
+      linkauth({alice, freebie}, alice, N(eosio.null), N(noop), freebie2, freebie));
+
+   // alice@freebie can unlinkauth
+   BOOST_REQUIRE_EQUAL(
+      "missing authority of alice1111111/active",
+      unlinkauth({alice, freebie}, alice, N(eosio.null), N(noop), active));
+   BOOST_REQUIRE_EQUAL(
+      "",
+      unlinkauth({alice, freebie}, alice, N(eosio.null), N(noop), freebie));
+
+   // alice@freebie can delete alice@freebie2
+   BOOST_REQUIRE_EQUAL(
+      "missing authority of alice1111111/active",
+      deleteauth({alice, freebie}, alice, freebie2, active));
+   BOOST_REQUIRE_EQUAL(
+      "",
+      deleteauth({alice, freebie}, alice, freebie2, freebie));
+
+   // bob, who has the published freebie key, attacks
+   BOOST_REQUIRE_EQUAL(
+      "",
+      updateauth({alice, freebie}, alice, freebie, active, get_public_key(bob, "attack"), freebie));
+} // extended_matching_tests
+FC_LOG_AND_RETHROW()
+
+// alice protects her account using allow_perms
+BOOST_FIXTURE_TEST_CASE(allow_perms_tests, limitauth_tester) try {
+   BOOST_REQUIRE_EQUAL(
+      "missing authority of alice1111111",
+      limitauthchg({bob, active}, alice, {owner, active, admin}, {}));
+   BOOST_REQUIRE_EQUAL(
+      "",
+      limitauthchg({alice, active}, alice, {owner, active, admin}, {}));
+
+   BOOST_REQUIRE_EQUAL(
+      "",
+      updateauth({alice, active}, alice, freebie, active, get_public_key(alice, "freebie"), active));
+   BOOST_REQUIRE_EQUAL(
+      "",
+      updateauth({alice, active}, alice, admin, active, get_public_key(alice, "admin"), active));
+   BOOST_REQUIRE_EQUAL(
+      "",
+      linkauth({alice, active}, alice, N(eosio.null), N(noop), freebie, active));
+   BOOST_REQUIRE_EQUAL(
+      "",
+      linkauth({alice, active}, alice, N(eosio.null), N(dosomething), admin, active));
+
+   // Bob, who has the published freebie key, tries using updateauth to modify alice@freebie
+   BOOST_REQUIRE_EQUAL(
+      "assertion failure with message: authorized_by is required for this account",
+      updateauth({alice, freebie}, alice, freebie, active, get_public_key(bob, "attack")));
+   BOOST_REQUIRE_EQUAL(
+      "assertion failure with message: authorized_by is required for this account",
+      updateauth({alice, freebie}, alice, freebie, active, get_public_key(bob, "attack"), N()));
+   BOOST_REQUIRE_EQUAL(
+      "assertion failure with message: authorized_by does not appear in allow_perms",
+      updateauth({alice, freebie}, alice, freebie, active, get_public_key(bob, "attack"), freebie));
+   BOOST_REQUIRE_EQUAL(
+      "missing authority of alice1111111/active",
+      updateauth({alice, freebie}, alice, freebie, active, get_public_key(bob, "attack"), active));
+
+   // alice@freebie can't create alice@freebie2
+   BOOST_REQUIRE_EQUAL(
+      "assertion failure with message: authorized_by does not appear in allow_perms",
+      updateauth({alice, freebie}, alice, freebie2, freebie, get_public_key(alice, "freebie2"), freebie));
+
+   // alice@active can create alice@freebie2
+   BOOST_REQUIRE_EQUAL(
+      "",
+      updateauth({alice, active}, alice, freebie2, freebie, get_public_key(alice, "freebie2"), active));
+
+   // Bob, who has the published freebie key, tries using linkauth
+   BOOST_REQUIRE_EQUAL(
+      "assertion failure with message: authorized_by is required for this account",
+      linkauth({alice, freebie}, alice, N(eosio.null), N(noop), freebie2));
+   BOOST_REQUIRE_EQUAL(
+      "assertion failure with message: authorized_by is required for this account",
+      linkauth({alice, freebie}, alice, N(eosio.null), N(noop), freebie2, N()));
+   BOOST_REQUIRE_EQUAL(
+      "assertion failure with message: authorized_by does not appear in allow_perms",
+      linkauth({alice, freebie}, alice, N(eosio.null), N(noop), freebie2, freebie));
+   BOOST_REQUIRE_EQUAL(
+      "missing authority of alice1111111/active",
+      linkauth({alice, freebie}, alice, N(eosio.null), N(noop), freebie2, active));
+
+   // Bob, who has the published freebie key, tries using deleteauth
+   BOOST_REQUIRE_EQUAL(
+      "assertion failure with message: authorized_by is required for this account",
+      deleteauth({alice, freebie}, alice, freebie2));
+   BOOST_REQUIRE_EQUAL(
+      "assertion failure with message: authorized_by is required for this account",
+      deleteauth({alice, freebie}, alice, freebie2, N()));
+   BOOST_REQUIRE_EQUAL(
+      "assertion failure with message: authorized_by does not appear in allow_perms",
+      deleteauth({alice, freebie}, alice, freebie2, freebie));
+   BOOST_REQUIRE_EQUAL(
+      "missing authority of alice1111111/owner",
+      deleteauth({alice, freebie}, alice, freebie2, owner));
+
+   // Bob, who has the published freebie key, tries using unlinkauth
+   BOOST_REQUIRE_EQUAL(
+      "assertion failure with message: authorized_by is required for this account",
+      unlinkauth({alice, freebie}, alice, N(eosio.null), N(noop)));
+   BOOST_REQUIRE_EQUAL(
+      "assertion failure with message: authorized_by is required for this account",
+      unlinkauth({alice, freebie}, alice, N(eosio.null), N(noop), N()));
+   BOOST_REQUIRE_EQUAL(
+      "assertion failure with message: authorized_by does not appear in allow_perms",
+      unlinkauth({alice, freebie}, alice, N(eosio.null), N(noop), freebie));
+   BOOST_REQUIRE_EQUAL(
+      "missing authority of alice1111111/active",
+      unlinkauth({alice, freebie}, alice, N(eosio.null), N(noop), active));
+
+   // alice@admin can do these
+   BOOST_REQUIRE_EQUAL(
+      "",
+      updateauth({alice, admin}, alice, admin2, admin, get_public_key(alice, "admin2"), admin));
+   BOOST_REQUIRE_EQUAL(
+      "",
+      linkauth({alice, admin}, alice, N(eosio.null), N(dosomething), admin2, admin));
+   BOOST_REQUIRE_EQUAL(
+      "",
+      unlinkauth({alice, admin}, alice, N(eosio.null), N(dosomething), admin));
+   BOOST_REQUIRE_EQUAL(
+      "",
+      deleteauth({alice, admin}, alice, admin2, admin));
+
+   // alice@active can do these
+   BOOST_REQUIRE_EQUAL(
+      "",
+      updateauth({alice, active}, alice, admin2, admin, get_public_key(alice, "admin2"), active));
+   BOOST_REQUIRE_EQUAL(
+      "",
+      linkauth({alice, active}, alice, N(eosio.null), N(dosomething), admin2, active));
+   BOOST_REQUIRE_EQUAL(
+      "",
+      unlinkauth({alice, active}, alice, N(eosio.null), N(dosomething), active));
+   BOOST_REQUIRE_EQUAL(
+      "",
+      deleteauth({alice, active}, alice, admin2, active));
+
+   // alice@owner can do these
+   BOOST_REQUIRE_EQUAL(
+      "",
+      updateauth({alice, owner}, alice, admin2, admin, get_public_key(alice, "admin2"), owner));
+   BOOST_REQUIRE_EQUAL(
+      "",
+      linkauth({alice, owner}, alice, N(eosio.null), N(dosomething), admin2, owner));
+   BOOST_REQUIRE_EQUAL(
+      "",
+      unlinkauth({alice, owner}, alice, N(eosio.null), N(dosomething), owner));
+   BOOST_REQUIRE_EQUAL(
+      "",
+      deleteauth({alice, owner}, alice, admin2, owner));
+} // allow_perms_tests
+FC_LOG_AND_RETHROW()
+
+// alice protects her account using disallow_perms
+BOOST_FIXTURE_TEST_CASE(disallow_perms_tests, limitauth_tester) try {
+   BOOST_REQUIRE_EQUAL(
+      "missing authority of alice1111111",
+      limitauthchg({bob, active}, alice, {}, {freebie, freebie2}));
+   BOOST_REQUIRE_EQUAL(
+      "",
+      limitauthchg({alice, active}, alice, {}, {freebie, freebie2}));
+
+   BOOST_REQUIRE_EQUAL(
+      "",
+      updateauth({alice, active}, alice, freebie, active, get_public_key(alice, "freebie"), active));
+   BOOST_REQUIRE_EQUAL(
+      "",
+      updateauth({alice, active}, alice, admin, active, get_public_key(alice, "admin"), active));
+   BOOST_REQUIRE_EQUAL(
+      "",
+      linkauth({alice, active}, alice, N(eosio.null), N(noop), freebie, active));
+   BOOST_REQUIRE_EQUAL(
+      "",
+      linkauth({alice, active}, alice, N(eosio.null), N(dosomething), admin, active));
+
+   // Bob, who has the published freebie key, tries using updateauth to modify alice@freebie
+   BOOST_REQUIRE_EQUAL(
+      "assertion failure with message: authorized_by is required for this account",
+      updateauth({alice, freebie}, alice, freebie, active, get_public_key(bob, "attack")));
+   BOOST_REQUIRE_EQUAL(
+      "assertion failure with message: authorized_by is required for this account",
+      updateauth({alice, freebie}, alice, freebie, active, get_public_key(bob, "attack"), N()));
+   BOOST_REQUIRE_EQUAL(
+      "assertion failure with message: authorized_by appears in disallow_perms",
+      updateauth({alice, freebie}, alice, freebie, active, get_public_key(bob, "attack"), freebie));
+   BOOST_REQUIRE_EQUAL(
+      "missing authority of alice1111111/active",
+      updateauth({alice, freebie}, alice, freebie, active, get_public_key(bob, "attack"), active));
+
+   // alice@freebie can't create alice@freebie2
+   BOOST_REQUIRE_EQUAL(
+      "assertion failure with message: authorized_by appears in disallow_perms",
+      updateauth({alice, freebie}, alice, freebie2, freebie, get_public_key(alice, "freebie2"), freebie));
+
+   // alice@active can create alice@freebie2
+   BOOST_REQUIRE_EQUAL(
+      "",
+      updateauth({alice, active}, alice, freebie2, freebie, get_public_key(alice, "freebie2"), active));
+
+   // Bob, who has the published freebie key, tries using linkauth
+   BOOST_REQUIRE_EQUAL(
+      "assertion failure with message: authorized_by is required for this account",
+      linkauth({alice, freebie}, alice, N(eosio.null), N(noop), freebie2));
+   BOOST_REQUIRE_EQUAL(
+      "assertion failure with message: authorized_by is required for this account",
+      linkauth({alice, freebie}, alice, N(eosio.null), N(noop), freebie2, N()));
+   BOOST_REQUIRE_EQUAL(
+      "assertion failure with message: authorized_by appears in disallow_perms",
+      linkauth({alice, freebie}, alice, N(eosio.null), N(noop), freebie2, freebie));
+   BOOST_REQUIRE_EQUAL(
+      "missing authority of alice1111111/active",
+      linkauth({alice, freebie}, alice, N(eosio.null), N(noop), freebie2, active));
+
+   // Bob, who has the published freebie key, tries using deleteauth
+   BOOST_REQUIRE_EQUAL(
+      "assertion failure with message: authorized_by is required for this account",
+      deleteauth({alice, freebie}, alice, freebie2));
+   BOOST_REQUIRE_EQUAL(
+      "assertion failure with message: authorized_by is required for this account",
+      deleteauth({alice, freebie}, alice, freebie2, N()));
+   BOOST_REQUIRE_EQUAL(
+      "assertion failure with message: authorized_by appears in disallow_perms",
+      deleteauth({alice, freebie}, alice, freebie2, freebie));
+   BOOST_REQUIRE_EQUAL(
+      "missing authority of alice1111111/owner",
+      deleteauth({alice, freebie}, alice, freebie2, owner));
+
+   // Bob, who has the published freebie key, tries using unlinkauth
+   BOOST_REQUIRE_EQUAL(
+      "assertion failure with message: authorized_by is required for this account",
+      unlinkauth({alice, freebie}, alice, N(eosio.null), N(noop)));
+   BOOST_REQUIRE_EQUAL(
+      "assertion failure with message: authorized_by is required for this account",
+      unlinkauth({alice, freebie}, alice, N(eosio.null), N(noop), N()));
+   BOOST_REQUIRE_EQUAL(
+      "assertion failure with message: authorized_by appears in disallow_perms",
+      unlinkauth({alice, freebie}, alice, N(eosio.null), N(noop), freebie));
+   BOOST_REQUIRE_EQUAL(
+      "missing authority of alice1111111/active",
+      unlinkauth({alice, freebie}, alice, N(eosio.null), N(noop), active));
+
+   // alice@admin can do these
+   BOOST_REQUIRE_EQUAL(
+      "",
+      updateauth({alice, admin}, alice, admin2, admin, get_public_key(alice, "admin2"), admin));
+   BOOST_REQUIRE_EQUAL(
+      "",
+      linkauth({alice, admin}, alice, N(eosio.null), N(dosomething), admin2, admin));
+   BOOST_REQUIRE_EQUAL(
+      "",
+      unlinkauth({alice, admin}, alice, N(eosio.null), N(dosomething), admin));
+   BOOST_REQUIRE_EQUAL(
+      "",
+      deleteauth({alice, admin}, alice, admin2, admin));
+
+   // alice@active can do these
+   BOOST_REQUIRE_EQUAL(
+      "",
+      updateauth({alice, active}, alice, admin2, admin, get_public_key(alice, "admin2"), active));
+   BOOST_REQUIRE_EQUAL(
+      "",
+      linkauth({alice, active}, alice, N(eosio.null), N(dosomething), admin2, active));
+   BOOST_REQUIRE_EQUAL(
+      "",
+      unlinkauth({alice, active}, alice, N(eosio.null), N(dosomething), active));
+   BOOST_REQUIRE_EQUAL(
+      "",
+      deleteauth({alice, active}, alice, admin2, active));
+
+   // alice@owner can do these
+   BOOST_REQUIRE_EQUAL(
+      "",
+      updateauth({alice, owner}, alice, admin2, admin, get_public_key(alice, "admin2"), owner));
+   BOOST_REQUIRE_EQUAL(
+      "",
+      linkauth({alice, owner}, alice, N(eosio.null), N(dosomething), admin2, owner));
+   BOOST_REQUIRE_EQUAL(
+      "",
+      unlinkauth({alice, owner}, alice, N(eosio.null), N(dosomething), owner));
+   BOOST_REQUIRE_EQUAL(
+      "",
+      deleteauth({alice, owner}, alice, admin2, owner));
+} // disallow_perms_tests
+FC_LOG_AND_RETHROW()
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/tests/eosio.limitauth_tests.cpp
+++ b/tests/eosio.limitauth_tests.cpp
@@ -239,6 +239,9 @@ BOOST_FIXTURE_TEST_CASE(allow_perms_tests, limitauth_tester) try {
       "missing authority of alice1111111",
       limitauthchg({bob, active}, alice, {owner, active, admin}, {}));
    BOOST_REQUIRE_EQUAL(
+      "allow_perms does not contain owner",
+      limitauthchg({alice, active}, alice, {active, admin}, {}));
+   BOOST_REQUIRE_EQUAL(
       "",
       limitauthchg({alice, active}, alice, {owner, active, admin}, {}));
 
@@ -370,6 +373,9 @@ BOOST_FIXTURE_TEST_CASE(disallow_perms_tests, limitauth_tester) try {
    BOOST_REQUIRE_EQUAL(
       "missing authority of alice1111111",
       limitauthchg({bob, active}, alice, {}, {freebie, freebie2}));
+   BOOST_REQUIRE_EQUAL(
+      "disallow_perms contains owner",
+      limitauthchg({alice, active}, alice, {}, {freebie, owner, freebie2}));
    BOOST_REQUIRE_EQUAL(
       "",
       limitauthchg({alice, active}, alice, {}, {freebie, freebie2}));


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->

* `limitauthchg` opts into or out of restrictions on `updateauth`, `deleteauth`, `linkauth`, and `unlinkauth`.
* `updateauth`, `deleteauth`, `linkauth`, and `unlinkauth` have a new binary extension argument: `authorized_by` (a permission). This may be either absent or empty for accounts which have not opted into `limitauthchg`.
* Accounts may opt into the new restrictions by passing non-empty `allow_perms` or `disallow_perms` to `limitauthchg`. They may opt out again by clearing both of these.
* If `allow_perms` is non-empty, then the `authorized_by` argument of the restricted actions must be in the vector, or the actions will abort.
* If `disallow_perms` is non-empty, then the `authorized_by` argument of the restricted actions must not be in the vector, or the actions will abort.
* In either case, the system contract verifies `authorized_by` authorized the action.

## Deployment Changes
- [ ] Deployment Changes
<!-- checked [x] = Deployment changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces a change to the contracts that causes deployment to change, please describe the impact. -->

## API Changes
- [x] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->

See above

## Documentation Additions
- [x] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
